### PR TITLE
Changed Progress bar to show the % done and the transfer rate. Fix CPU usage.

### DIFF
--- a/lib/raw_write.py
+++ b/lib/raw_write.py
@@ -4,6 +4,7 @@ import commands
 from subprocess import Popen,PIPE,call,STDOUT
 import os, sys
 import getopt
+import time
 
 def raw_write(source, target):
     bs = 1024
@@ -12,13 +13,15 @@ def raw_write(source, target):
     total_size = float(os.path.getsize(source))
     print total_size
     output = open(target, 'wb')
+    start_time = time.time()
     while True:
 	buffer = input.read(bs)
 	if len(buffer) == 0:
 	  break
 	output.write(buffer)
 	size = size + bs
-	print size/total_size
+	elapsed_time = time.time() - start_time
+	print "%f %f" % (size/total_size,size/elapsed_time)
 
     output.flush()    
     #os.fsync(output.fileno())


### PR DESCRIPTION
The progress bar now shows the transfer rate and percentage complete
instead of the source and destination.

The rapid updating of the progress bar was killing the CPU performance
and causing the Xorg process to eat up a CPU on my LMDE system. By only updating the progress bar if the percent complete value changes stop this from happening.
