### PR TITLE
Sandisk USB sticks fix

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -205,7 +205,9 @@ class MintStick:
             dev = dbus.Interface(dev_obj, "org.freedesktop.DBus.Properties")
             if (str(dev.Get('', 'DriveConnectionInterface')) == 'usb') \
                 and (str(dev.Get('', 'DeviceSize')) != "0") \
-                and (str(dev.Get('', 'DeviceIsOpticalDisc')) == "0"):
+                and (str(dev.Get('', 'DeviceIsOpticalDisc')) == "0") \
+                and (str(dev.Get('', 'DriveIsRotational')) == "0") \
+                and (str(dev.Get('', 'DeviceIsDrive')) == "0"):
                     name = str(dev.Get('', 'DeviceFile'))
                     drivemodel = str(dev.Get('', 'DriveModel'))
                     name = ''.join([i for i in name if not i.isdigit()])                        

--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -204,7 +204,6 @@ class MintStick:
             dev_obj = bus.get_object("org.freedesktop.UDisks", dev)
             dev = dbus.Interface(dev_obj, "org.freedesktop.DBus.Properties")
             if (str(dev.Get('', 'DriveConnectionInterface')) == 'usb') \
-                and (str(dev.Get('', 'DeviceIsRemovable')) == "1") \
                 and (str(dev.Get('', 'DeviceSize')) != "0") \
                 and (str(dev.Get('', 'DeviceIsOpticalDisc')) == "0"):
                     name = str(dev.Get('', 'DeviceFile'))


### PR DESCRIPTION
Newer, for Windows 8 certified, USB sticks are often marked as non removable. To issue this, I removed code from line 207. My personal Sandisk Cruzer Edge USB stick is now recognized correctly.