### PR TITLE
Add integration with Ubuntu's Unity 7

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -7,7 +7,7 @@ import signal
 import re
 import gettext
 import locale
-from gi.repository import Unity, GObject, Gio, Polkit, Gtk, GLib
+from gi.repository import GObject, Gio, Polkit, Gtk, GLib
 import sys
 import getopt
 import dbus


### PR DESCRIPTION
This is what I hope a rather non-intrusive change which adds support for Ubuntu's Unity 7. When writing an image, a progress bar shown over the launcher button. If writing is successful, the launcher button will "jiggle". Makes it easier to keep track of it if I'm doing something else.
 
Please review the patch and let me know if I need to change anything.