### PR TITLE
Updated pkexec support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,19 +23,20 @@ DATAFILES="mintstick.glade mintstick.ui"
 if [ "$1" = "uninstall" ]; then
     rm -rf /usr/lib/mintstick
     rm -rf /usr/share/mintstick
-    rm -r /usr/share/applications/mintstick.desktop
-    rm -r /usr/share/applications/mintstick-kde.desktop
-    rm -r /usr/share/applications/mintstick-format.desktop
-    rm -r /usr/share/applications/mintstick-kde-format.desktop
+    rm -f /usr/share/applications/mintstick.desktop
+    rm -f /usr/share/applications/mintstick-kde.desktop
+    rm -f /usr/share/applications/mintstick-format.desktop
+    rm -f /usr/share/applications/mintstick-kde-format.desktop
     rm -f /usr/bin/mintstick
-    rm -rf /usr/share/polkit-1/actions/org.linuxmint.im.policy
-    rm -rf /usr/share/kde4/apps/solid/actions/mintstick-format.desktop
+    rm -f /usr/share/polkit-1/actions/org.linuxmint.im.policy  # old name 
+    rm -f /usr/share/polkit-1/actions/com.linuxmint.mintstick.policy
+    rm -f /usr/share/kde4/apps/solid/actions/mintstick-format.desktop
 else
     cp share/applications/mintstick.desktop /usr/share/applications/
     cp share/applications/mintstick-format.desktop /usr/share/applications/
     cp share/applications/mintstick-kde.desktop /usr/share/applications/
     cp share/applications/mintstick-format-kde.desktop /usr/share/applications/
-    cp share/polkit/org.linuxmint.im.policy /usr/share/polkit-1/actions
+    cp share/polkit/com.linuxmint.mintstick.policy /usr/share/polkit-1/actions/
     cp share/kde4/mintstick-format_action.desktop /usr/share/kde4/apps/solid/actions
     cp mintstick /usr/bin/
     mkdir -p /usr/lib/mintstick

--- a/makepot
+++ b/makepot
@@ -1,5 +1,11 @@
 #!/bin/bash
 
 intltool-extract --type=gettext/glade share/mintstick/mintstick.ui
-xgettext --language=Python --keyword=_ --keyword=N_ --output=mintstick.pot lib/mintstick.py generate_additional_files.py share/mintstick/mintstick.ui.h
+
+xgettext --language=Python --keyword=_ --keyword=N_ --output=mintstick.pot \
+  lib/mintstick.py \
+  generate_additional_files.py \
+  share/mintstick/mintstick.ui.h
+xgettext --its=polkit.its -L PolkitPolicy --output=mintstick.pot --join-existing share/polkit/*.policy
+
 rm -f share/mintstick/mintstick.ui.h

--- a/polkit.its
+++ b/polkit.its
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           version="2.0">
+  <its:translateRule selector="/action/description |
+                               /action/message"
+                     translate="yes"/>
+</its:rules>

--- a/polkit.loc
+++ b/polkit.loc
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<locatingRules>
+  <locatingRule name="PolkitPolicy" pattern="*.policy">
+    <documentRule localName="policyconfig" target="polkit.its"/>
+  </locatingRule>
+</locatingRules>

--- a/share/polkit/com.linuxmint.mintstick.policy
+++ b/share/polkit/com.linuxmint.mintstick.policy
@@ -4,18 +4,18 @@
  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
 <policyconfig>
 
-  <vendor>linuxmint</vendor>
-  <vendor_url>http://hal.freedesktop.org/docs/PolicyKit/</vendor_url>
+  <vendor>Linux Mint</vendor>
+  <vendor_url>https://linuxmint.com/</vendor_url>
 
-  <action id="org.freedesktop.policykit.pkexec.run-im">
-    <description>USB Image Writer Authentication dialog</description>
+  <action id="com.linuxmint.mintstick">
+    <description>USB Image Writer/USB Stick Formatter authentication dialog</description>
     <message>This will destroy all data on the target device, are you sure you want to proceed?</message>
     <message xml:lang="fr">Toutes les données contenues sur ce périphérique vont être détruites. Souhaitez-vous continuer ?</message>
-    <icon_name>system-run</icon_name>
+    <icon_name>usb-creator</icon_name>
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_self_keep</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/python2</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">/usr/lib/linuxmint/mintstick/raw_write.py</annotate>


### PR DESCRIPTION
See https://github.com/linuxmint/mintsources/issues/75

About L10n:  
- String `share/mintstick/mintstick.ui.h:2` is similar to the `<message>` that's in the `.policy` file; "target device" might be better than "USB stick" in case the user selects a device (such as an SD card) that isn't a USB stick.  
- This version of the `.policy` file has a translation of the `<message>` into French, which should be kept when translating this file.  