### PR TITLE
added --version flag

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -558,8 +558,13 @@ if __name__ == "__main__":
         print "                           [-f|--filesystem] filesystem"
         exit (0)
 
+    def version():
+        print "mintstick 1.3.3"
+        print "for help use --help"
+        exit (0)
+
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hm:i:u:f:", ["debug", "help", "mode=", "iso=","usb=","filesystem="])
+        opts, args = getopt.getopt(sys.argv[1:], "hm:i:u:f:", ["debug", "help", "mode=", "iso=","usb=","filesystem=","version"])
     except getopt.error, msg:
         print msg
         print "for help use --help"
@@ -581,6 +586,8 @@ if __name__ == "__main__":
             mode=a
         elif o in ("--debug"):
             debug = True
+        elif o in ("--version"):
+            version()
 
     argc = len(sys.argv)
     if argc > 8:


### PR DESCRIPTION
This adds a `--version` flag to the command line. E.g.:
```
$ mintstick --version
mintstick 1.3.3
for help use --help
```

The version number is hard-coded in... if this is merged it might be useful to have another way of finding the version.