### PR TITLE
Add exFAT format option

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,8 @@ Depends:
  python, python-parted,
  gir1.2-udisks-2.0,
  gir1.2-xapp-1.0,
- util-linux
+ util-linux,
+ exfat-utils
 Conflicts: usb-imagewriter
 Replaces: usb-imagewriter
 Description: write .img and .iso files to USB sticks

--- a/lib/raw_format.py
+++ b/lib/raw_format.py
@@ -22,7 +22,7 @@ def raw_format(device_path, fstype, volume_label, uid, gid):
     if fstype == "fat32":
         partition_type = "fat32"
     elif fstype == "exfat":
-        partition_type = "exfat"
+        partition_type = "ntfs"
     elif fstype == "ntfs":
         partition_type = "ntfs"
     elif fstype == "ext4":

--- a/lib/raw_format.py
+++ b/lib/raw_format.py
@@ -21,7 +21,9 @@ def raw_format(device_path, fstype, volume_label, uid, gid):
     partition_path = "%s1" % device_path
     if fstype == "fat32":
         partition_type = "fat32"
-    if fstype == "ntfs":
+    elif fstype == "exfat":
+        partition_type = "exfat"
+    elif fstype == "ntfs":
         partition_type = "ntfs"
     elif fstype == "ext4":
         partition_type = "ext4"
@@ -42,7 +44,9 @@ def raw_format(device_path, fstype, volume_label, uid, gid):
     # Format the FS on the partition
     if fstype == "fat32":
         execute(["mkdosfs", "-F", "32", "-n", volume_label, partition_path])
-    if fstype == "ntfs":
+    elif fstype == "exfat":
+        execute(["mkfs.exfat", "-n", volume_label, partition_path])
+    elif fstype == "ntfs":
         execute(["mkntfs", "-f", "-L", volume_label, partition_path])
     elif fstype == "ext4":
         execute(["mkfs.ext4", "-E", "root_owner=%s:%s" % (uid, gid), "-L", volume_label, partition_path])
@@ -72,8 +76,8 @@ def main():
         elif o in ("-d"):
             device = a
         elif o in ("-f"):
-            if a not in [ "fat32", "ntfs", "ext4" ]:
-                print "Specify fat32, ntfs or ext4"
+            if a not in [ "fat32", "exfat", "ntfs", "ext4" ]:
+                print "Specify fat32, exfat, ntfs or ext4"
                 sys.exit(3)
             fstype = a
         elif o in ("-l"):

--- a/share/mintstick/mintstick.ui
+++ b/share/mintstick/mintstick.ui
@@ -269,8 +269,8 @@
                         <property name="sensitive">False</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">FAT32 
-   + Compatible everywhere.
-   -  Cannot handle files larger than 4GB.
+  + Compatible everywhere.
+  -  Cannot handle files larger than 4GB.
 
 exFAT
   + Compatible almost everywhere.

--- a/share/mintstick/mintstick.ui
+++ b/share/mintstick/mintstick.ui
@@ -272,16 +272,20 @@
    + Compatible everywhere.
    -  Cannot handle files larger than 4GB.
 
+exFAT
+  + Compatible almost everywhere.
+  + Can handle files larger than 4GB.
+  -  Not as compatible as FAT32.
+
 NTFS 
   + Compatible with Windows.
-   - Not compatible with Mac and most hardware devices.
-   - Occasional compatibility problems with Linux (NTFS is proprietary and reverse engineered).
+  -  Not compatible with Mac and most hardware devices.
+  -  Occasional compatibility problems with Linux (NTFS is proprietary and reverse engineered).
 
 EXT4 
-
   + Modern, stable, fast, journalized.
   + Supports Linux file permissions.
-   - Not compatible with Windows, Mac and most hardware devices.
+  -  Not compatible with Windows, Mac and most hardware devices.
 </property>
                       </object>
                       <packing>


### PR DESCRIPTION
Adds exFAT format option to mintstick as suggested in #60. exFAT allows for files larger than 4GB, a limitation of FAT32.

New dependency on exfat-utils. Is already installed on Linux Mint 18+ and LMDE 2 (2017 ISO).

exfat-fuse is needed to read & write the filesystem but not to format. As such I've not added that as a dependency.