### PR TITLE
accidentally swapped nemo-action icons

### DIFF
--- a/generate_additional_files.py
+++ b/generate_additional_files.py
@@ -61,7 +61,7 @@ additionalfiles.generate(DOMAIN, PATH, "share/applications/mintstick-format-kde.
 prefix="""[Nemo Action]
 Active=true
 Exec=mintstick -m iso -i "%F"
-Icon-Name=edit-clear-all-symbolic
+Icon-Name=media-removable-symbolic
 Selection=S
 Extensions=iso;img;
 """
@@ -70,7 +70,7 @@ additionalfiles.generate(DOMAIN, PATH, "share/nemo/actions/mintstick.nemo_action
 prefix="""[Nemo Action]
 Active=true
 Exec=mintstick -m format -u %D
-Icon-Name=media-removable-symbolic
+Icon-Name=edit-clear-all-symbolic
 Selection=S
 Extensions=any;
 Conditions=removable;

--- a/share/nemo/actions/mintstick-format.nemo_action
+++ b/share/nemo/actions/mintstick-format.nemo_action
@@ -1,7 +1,7 @@
 [Nemo Action]
 Active=true
 Exec=mintstick -m format -u %D
-Icon-Name=media-removable-symbolic
+Icon-Name=edit-clear-all-symbolic
 Selection=S
 Extensions=any;
 Conditions=removable;

--- a/share/nemo/actions/mintstick.nemo_action
+++ b/share/nemo/actions/mintstick.nemo_action
@@ -1,7 +1,7 @@
 [Nemo Action]
 Active=true
 Exec=mintstick -m iso -i "%F"
-Icon-Name=edit-clear-all-symbolic
+Icon-Name=media-removable-symbolic
 Selection=S
 Extensions=iso;img;
 Name=Make bootable USB stick


### PR DESCRIPTION
The format icon shows up for "Create bootable USB-stick"
and the usb icon shows up for "Format"

This has to be swapped