### PR TITLE
Made accessible for users with screen reader

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -97,6 +97,11 @@ class MintStick:
             self.progressbar = self.wTree.get_object("progressbar")
             self.chooser = self.wTree.get_object("filechooserbutton")
 
+            # Making file chooser accessible for users with screen reader
+            label = self.wTree.get_object("label_write_image")
+            button = self.chooser.get_children()[0]
+            label.set_mnemonic_widget(button)
+
             # Devicelist model
             self.devicemodel = Gtk.ListStore(str, str)
 

--- a/share/mintstick/mintstick.ui
+++ b/share/mintstick/mintstick.ui
@@ -226,6 +226,8 @@
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="xpad">5</property>
+                        <property name="use_underline">True</property>
+                        <property name="mnemonic_widget">formatdevice_combobox</property>
                         <property name="label" translatable="yes">Format:</property>
                       </object>
                       <packing>
@@ -255,6 +257,8 @@
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="xpad">5</property>
+                        <property name="use_underline">True</property>
+                        <property name="mnemonic_widget">filesystem_combobox</property>
                         <property name="label" translatable="yes">as</property>
                       </object>
                       <packing>
@@ -313,6 +317,8 @@ EXT4
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="xpad">5</property>
+                        <property name="use_underline">True</property>
+                        <property name="mnemonic_widget">volume_label_entry</property>
                         <property name="label" translatable="yes">Volume label:</property>
                       </object>
                       <packing>
@@ -492,7 +498,7 @@ EXT4
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkLabel" id="label23">
+                      <object class="GtkLabel" id="label_write_image">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
@@ -527,6 +533,8 @@ EXT4
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="xpad">5</property>
+                        <property name="use_underline">True</property>
+                        <property name="mnemonic_widget">device_combobox</property>
                         <property name="label" translatable="yes">to</property>
                       </object>
                       <packing>


### PR DESCRIPTION
This will make Mintstick accessible for visually impaired users. 
In Accessible-Coconut GNU/Linux operating system we are providing this updated version of Mintstick. 
More info : http://www.zendalona.com/accessible-coconut  