### PR TITLE
Fix elevation error (W.I.P.; advice sought)

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -374,6 +374,11 @@ class MintStick:
             return False
         elif rc == 5:
             message = _("An error occured while creating a partition on %s.") % usb_path
+        elif rc == 126:
+            # Elevation was cancelled.
+            self.set_format_sensitive()
+            self.udisks_client.handler_unblock(self.udisk_listener_id)
+            return False
         elif rc == 127:
             message = _('Authentication Error.')
         else:

--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -415,13 +415,19 @@ class MintStick:
         str_progress = "%3.0f%%" % (float(size) * 100)
         int_progress = int(float(size) * 100)
         self.progressbar.set_text(str_progress)
-        self.window.set_title("%s - %s" % (str_progress, _("USB Image Writer")))
+        if self.mode == "normal":
+          self.window.set_title("%s - %s" % (str_progress, _("USB Image Writer")))
+        else:
+          self.window.set_title("%s - %s" % (str_progress, _("USB Stick Formatter")))
         XApp.set_window_progress_pulse(self.window, False)
         XApp.set_window_progress(self.window, int_progress)
 
     def pulse_progress(self):
         self.progressbar.pulse()
-        self.window.set_title(_("USB Image Writer"))
+        if self.mode == "normal":
+          self.window.set_title(_("USB Image Writer"))
+        else:
+           self.window.set_title(_("USB Stick Formatter"))
         XApp.set_window_progress_pulse(self.window, True)
 
     def update_progress(self, fd, condition):
@@ -523,7 +529,10 @@ class MintStick:
         self.devicelist.set_sensitive(False)
         self.go_button.set_sensitive(False)
         self.progressbar.set_sensitive(False)
-        self.window.set_title(_("USB Image Writer"))
+        if self.mode == "normal":
+          self.window.set_title(_("USB Image Writer"))
+        else:
+          self.window.set_title(_("USB Stick Formatter"))
 
     def close(self, widget):
         self.write_logfile()

--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -420,19 +420,13 @@ class MintStick:
         str_progress = "%3.0f%%" % (float(size) * 100)
         int_progress = int(float(size) * 100)
         self.progressbar.set_text(str_progress)
-        if self.mode == "normal":
-          self.window.set_title("%s - %s" % (str_progress, _("USB Image Writer")))
-        else:
-          self.window.set_title("%s - %s" % (str_progress, _("USB Stick Formatter")))
+        self.window.set_title("%s - %s" % (str_progress, _("USB Image Writer")))
         XApp.set_window_progress_pulse(self.window, False)
         XApp.set_window_progress(self.window, int_progress)
 
     def pulse_progress(self):
         self.progressbar.pulse()
-        if self.mode == "normal":
-          self.window.set_title(_("USB Image Writer"))
-        else:
-           self.window.set_title(_("USB Stick Formatter"))
+        self.window.set_title(_("USB Image Writer"))
         XApp.set_window_progress_pulse(self.window, True)
 
     def update_progress(self, fd, condition):
@@ -534,10 +528,7 @@ class MintStick:
         self.devicelist.set_sensitive(False)
         self.go_button.set_sensitive(False)
         self.progressbar.set_sensitive(False)
-        if self.mode == "normal":
-          self.window.set_title(_("USB Image Writer"))
-        else:
-          self.window.set_title(_("USB Stick Formatter"))
+        self.window.set_title(_("USB Image Writer"))
 
     def close(self, widget):
         self.write_logfile()


### PR DESCRIPTION
Stop cancelling the elevation prompt from showing any error; see #53.

At present this would-be fix is not really a fix. The 'fix' does prevent the cancelling from showing an error. However:

1. after cancellation, the throbber shows as job-done;
2. after cancellation, the 'format' button does not work properly.