### PR TITLE
control: depend on exfat-utils or exfatprogs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends:
  gir1.2-udisks-2.0,
  gir1.2-xapp-1.0,
  util-linux,
- exfatprogs
+ exfatprogs | exfat-utils
 Conflicts: usb-imagewriter
 Replaces: usb-imagewriter
 Description: write .img and .iso files to USB sticks

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends:
  gir1.2-udisks-2.0,
  gir1.2-xapp-1.0,
  util-linux,
- exfat-utils
+ exfatprogs
 Conflicts: usb-imagewriter
 Replaces: usb-imagewriter
 Description: write .img and .iso files to USB sticks


### PR DESCRIPTION
For the 22.04 package base the exfat-utils package is replaced with exfatprogs. Update the control file to depend on either, so it works for 18.04, 20.04 and 22.04 package base.

Fixes #100