### PR TITLE
Remove redundant block device check

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -236,12 +236,8 @@ class MintStick:
                         removable = bool(drive.get_property('removable'))
 
                         if is_usb and size > 0 and removable and not optical:
-                            name = _("unknown")
-
-                            block = obj.get_block()
-                            if block is not None:
-                                name = block.get_property('device')
-                                name = ''.join([i for i in name if not i.isdigit()])
+                            name = block.get_property('device')
+                            name = ''.join([i for i in name if not i.isdigit()])
 
                             drive_vendor = str(drive.get_property('vendor'))
                             drive_model = str(drive.get_property('model'))


### PR DESCRIPTION
Hi,  
This MR removes a redundant block check.  

While listing available usb block devices, the udev block device object is queried twice, the second time within the existing object scope.  
As the device is already defined, there's no need to set a temporary `unknown` name to it.  

This was tested by:
1) Checking that the two block were actually the same object before removing it;  
2) Formatting an USB key before and after the changes and seeing the operations successfully complete.  

Thanks,
Cyril