### PR TITLE
Add support for cpio devices

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -183,7 +183,7 @@ class MintStick:
                 if block is not None:
                     drive = self.udisks_client.get_drive_for_block(block)
                     if drive is not None:
-                        is_usb = str(drive.get_property("connection-bus")) == 'usb'
+                        is_usb = str(drive.get_property('connection-bus')) in ['usb', 'cpio']
                         size = int(drive.get_property('size'))
                         optical = bool(drive.get_property('optical'))
                         removable = bool(drive.get_property('removable'))


### PR DESCRIPTION
This MR aims to add support for cpio block devices, under which sd cards are sometimes represented.  

On my laptop (Starlab Starlite Mk IV), the sd card shows up as a `cpio` device rather than `usb`.  
As such, it was not listed in available devices, whereas I'd expect to be able to format it. 

Before applying the changes, I see no available devices, although the sd card is inserted:  
![image](https://user-images.githubusercontent.com/2159577/200597911-18f8793d-d8e5-445f-bf60-53e3f6aeb368.png)

Following the changes, the sd card is correctly listed:
![image](https://user-images.githubusercontent.com/2159577/200598269-8d73dfb0-85e0-4c8f-b1d5-63a4eb976b98.png)

I ensured these were not breaking other devices by:
- Booting a live usb Linux Mint,  
- Adding a usb cd drive, which is not listed as expected,  
- Checking that internal drives were also not listed.

I'm also open to updating appearances of `USB Stick` to `Removable Drives` in user strings if you like :slightly_smiling_face: 

Closes #72 

Thanks,
Cyril