### PR TITLE
better option evaluation

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -497,7 +497,7 @@ if __name__ == "__main__":
             filesystem = a
         elif o in ("-m", "--mode"):
             mode = a
-        elif o in "--debug":
+        elif o == "--debug":
             debug = True
 
     argc = len(sys.argv)

--- a/lib/raw_format.py
+++ b/lib/raw_format.py
@@ -73,18 +73,18 @@ def main():
             print("-g|--gid             : gid of user\n")
             print("Example : %s -d /dev/sdj -f fat32 -l \"USB Stick\" -u 1000 -g 1000" % sys.argv[0])
             sys.exit(0)
-        elif o in ("-d"):
+        elif o == "-d":
             device = a
-        elif o in ("-f"):
+        elif o == "-f":
             if a not in [ "fat32", "exfat", "ntfs", "ext4" ]:
                 print("Specify fat32, exfat, ntfs or ext4")
                 sys.exit(3)
             fstype = a
-        elif o in ("-l"):
+        elif o == "-l":
             label = a
-        elif o in ("-u"):
+        elif o == "-u":
             uid = a
-        elif o in ("-g"):
+        elif o in "-g":
             gid = a
 
     argc = len(sys.argv)

--- a/lib/raw_write.py
+++ b/lib/raw_write.py
@@ -68,9 +68,9 @@ def main():
             print("-t|--target          : target device path\n")
             print("Example : %s -s /foo/image.iso -t /dev/sdj" % sys.argv[0])
             sys.exit(0)
-        elif o in ("-s"):
+        elif o == "-s":
             source = a
-        elif o in ("-t"):
+        elif o == "-t":
             target = a
 
     argc = len(sys.argv)


### PR DESCRIPTION
Python performance different when asked if some string is in a list of strings or in a string.
If you ask python `o in ("-d")` `o` could be empty, `-`, `d` and `-d`, but we want only `-d` to be valid.

`getopt.getopt` should prevent such options, but still I think it's more clear to directly check by equality (`==`).