### PR TITLE
remove unused imports

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
 
-from subprocess import Popen, PIPE, call, STDOUT
+from subprocess import Popen, PIPE
 import getopt
 import gettext
 import gi
 import locale
 import os
-import re
 import signal
 import subprocess
 import sys
@@ -16,7 +15,7 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('UDisks', '2.0')
 gi.require_version('XApp', '1.0')
 
-from gi.repository import GObject, Gio, Polkit, Gtk, GLib, UDisks, XApp
+from gi.repository import Polkit, Gtk, GLib, UDisks, XApp
 
 try:
     gi.require_version('Unity', '7.0')

--- a/lib/mountutils.py
+++ b/lib/mountutils.py
@@ -1,6 +1,5 @@
-import os, sys
-import subprocess
-from subprocess import Popen,PIPE,call,STDOUT
+import sys
+from subprocess import call
 
 def do_umount(target):
         mounts = get_mounted(target)

--- a/lib/raw_format.py
+++ b/lib/raw_format.py
@@ -1,12 +1,10 @@
 #!/usr/bin/python3
 
-import subprocess
-from subprocess import Popen,PIPE,call,STDOUT
-import os, sys
+from subprocess import call
+import sys
 import getopt
-import parted
 sys.path.append('/usr/lib/mintstick')
-from mountutils import *
+from mountutils import do_umount
 import syslog
 
 def execute(command):

--- a/lib/raw_write.py
+++ b/lib/raw_write.py
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 
-import subprocess
-from subprocess import Popen,PIPE,call,STDOUT
 import os, sys
 import getopt
 sys.path.append('/usr/lib/mintstick')
-from mountutils import *
+from mountutils import do_umount
 import parted
 
 def raw_write(source, target):


### PR DESCRIPTION
I removed all unused imports and explicitly named the function imported from `mountutils`.