### PR TITLE
remove unused local variables

### DIFF
--- a/lib/raw_write.py
+++ b/lib/raw_write.py
@@ -12,12 +12,11 @@ def raw_write(source, target):
     size=0
     input = open(source, 'rb')
     total_size = float(os.path.getsize(source))
-    #print total_size
 
     # Check if the ISO can fit ... :)
     device = parted.getDevice(target)
     device_size = device.getLength() * device.sectorSize
-    if (device.getLength() * device.sectorSize) < float(os.path.getsize(source)):
+    if device_size < float(os.path.getsize(source)):
         input.close()
         print("nospace")
         exit(3)

--- a/lib/verify.py
+++ b/lib/verify.py
@@ -139,7 +139,6 @@ class App():
                     sums = f"{MINT_MIRROR}/testing/sha256sum.txt"
                 elif self.filename.endswith(".iso"):
                     # extract version number
-                    version = self.filename.split("-")[1]
                     sums = f"{MINT_MIRROR}/debian/sha256sum.txt"
                 gpg = sums + ".gpg"
             elif self.filename.startswith("ubuntu-"):
@@ -317,7 +316,6 @@ class App():
             self.show_result("dialog-error", _("An error occurred"), details=[str(e)])
 
     def check_integrity(self):
-        expected_line = f"{self.sha256sum} *{self.filename}"
         with open(PATH_SUMS) as sums_file:
             for line in sums_file:
                 line = line.strip()


### PR DESCRIPTION
I replaced the duplicated code by the local variable `device_size`.
The other two variables `version` and `expected_line` are unused.