### PR TITLE
Quote parameters in shell scripts

### DIFF
--- a/bin/mint-stick-format
+++ b/bin/mint-stick-format
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec python3 -u /usr/lib/mintstick/raw_format.py $@
+exec python3 -u /usr/lib/mintstick/raw_format.py "$@"

--- a/bin/mint-stick-write
+++ b/bin/mint-stick-write
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec python3 -u /usr/lib/mintstick/raw_write.py $@
+exec python3 -u /usr/lib/mintstick/raw_write.py "$@"


### PR DESCRIPTION
After selecting a file in a directory with whitespace in its name mintstick can't do the action because the `mint-stick-format` and `mint-stick-write` shell scripts didn't quote the parameters thus splitting the path into multiple (too many) arguments.