### PR TITLE
python3-unidecode: Added to depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Depends:
  python3-gi,
  python3-parted,
  python3-gnupg,
+ python3-unidecode,
  gir1.2-udisks-2.0,
  gir1.2-xapp-1.0,
  util-linux,


### PR DESCRIPTION
python3-unidecode: Added to depends

Fix for "ModuleNotFoundError: No module named 'unidecode'".

`Traceback (most recent call last):
  File "/usr/lib/mintstick/mintstick.py", line 3, in <module>
    from unidecode import unidecode
ModuleNotFoundError: No module named 'unidecode'`