### PR TITLE
verify: adds timeout to requests.get() calls

### DIFF
--- a/lib/verify.py
+++ b/lib/verify.py
@@ -225,10 +225,11 @@ class App():
 
     def verify_url(self, button):
         # Download files
+        timeout = (3.05, 27)
         try:
             with open(PATH_SUMS, "wb") as file:
                 url = self.builder.get_object("entry_url_sums").get_text()
-                response = requests.get(url)
+                response = requests.get(url, timeout=timeout)
                 response.raise_for_status()
                 file.write(response.content)
         except:
@@ -237,7 +238,7 @@ class App():
         try:
             with open(PATH_GPG, "wb") as file:
                 url = self.builder.get_object("entry_url_gpg").get_text()
-                response = requests.get(url)
+                response = requests.get(url, timeout=timeout)
                 response.raise_for_status()
                 file.write(response.content)
         except:


### PR DESCRIPTION
By default, `requests.get()` has an indefinite timeout. If there is a upstream network disruption preventing access to the resource, the verify dialog becomes unresponsive when trying to verify an ISO because it waits forever to download the signatures and hashes.

In dual stack internet connections, the timeout is needed to retry with the ipv4 connection if there is a disruption on the initial ipv6 connection.