### PR TITLE
Limit exFAT volume label length to 11 characters

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -136,7 +136,7 @@ class MintStick:
             self.fsmodel = Gtk.ListStore(str, str, int, bool, bool)
             #                     id       label    max-length force-upper-case   force-alpha-numeric
             self.fsmodel.append(["fat32", "FAT32", 11, True, True])
-            self.fsmodel.append(["exfat", "exFAT", 15, False, False])
+            self.fsmodel.append(["exfat", "exFAT", 11, False, False])
             self.fsmodel.append(["ntfs", "NTFS", 32, False, False])
             self.fsmodel.append(["ext4", "EXT4", 16, False, False])
             self.filesystemlist.set_model(self.fsmodel)


### PR DESCRIPTION
Fixes #146

mintstick currently allows exFAT labels longer than 11 characters during formatting.

On Debian 12, formatting succeeds, but the device cannot be mounted afterward when the label exceeds 11 characters. This is reproducible both via GVFS/UDisks2 and the standard mount command.

This patch limits exFAT labels to 11 characters to prevent creating unusable volumes.