### PR TITLE
Add 'Format another' button to format result page

### DIFF
--- a/lib/mintstick.py
+++ b/lib/mintstick.py
@@ -165,6 +165,9 @@ class MintStick:
                         self.filesystemlist.set_active_iter(fs_iter)
                     fs_iter = self.fsmodel.iter_next(fs_iter)
 
+            self.format_back_button = self.wTree.get_object("format_back_button")
+            self.format_back_button.connect("clicked", self.on_format_back)
+
             self.get_devices()
             self.select_device(usb_path_arg)
 
@@ -513,6 +516,11 @@ class MintStick:
         self.devicelist.set_sensitive(True)
         self.go_button.set_sensitive(True)
         self.verify_button.set_sensitive(True)
+
+    def on_format_back(self, widget):
+        self.clear_progress()
+        self.wTree.get_object("format_stack").set_visible_child_name("format_page")
+        self.set_format_sensitive(True)
 
     def set_format_sensitive(self, reset=True):
         if reset:

--- a/share/mintstick/mintstick.ui
+++ b/share/mintstick/mintstick.ui
@@ -250,6 +250,20 @@ EXT4
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="format_back_button">
+                <property name="label" translatable="yes">Format another</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="halign">center</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="name">format_result_page</property>


### PR DESCRIPTION
After formatting completes, a 'Format another' button appears that returns to the format page, refreshes the device list and re-enables controls for formatting another USB stick.